### PR TITLE
Apply setSampleRate change to VoiceHandler ProcessorRouters

### DIFF
--- a/src/smooth_value.cpp
+++ b/src/smooth_value.cpp
@@ -25,8 +25,12 @@ namespace mopo {
   SmoothValue::SmoothValue(mopo_float value) :
       Value(value), target_value_(value) { }
 
-  void SmoothValue::process() {
+  void SmoothValue::setSampleRate(int sample_rate) {
+    sample_rate_ = sample_rate;
     decay_ = 1 - exp(-2.0 * PI * SMOOTH_CUTOFF / sample_rate_);
+  }
+
+  void SmoothValue::process() {
     for (int i = 0; i < BUFFER_SIZE; ++i)
       outputs_[0]->buffer[i] = tick();
   }

--- a/src/smooth_value.h
+++ b/src/smooth_value.h
@@ -29,6 +29,8 @@ namespace mopo {
       virtual Processor* clone() const { return new SmoothValue(*this); }
       virtual void process();
 
+      virtual void setSampleRate(int sample_rate);
+
       void set(mopo_float value) { target_value_ = value; }
       void setHard(mopo_float value) {
         Value::set(value);

--- a/src/voice_handler.cpp
+++ b/src/voice_handler.cpp
@@ -75,6 +75,8 @@ namespace mopo {
   }
 
   void VoiceHandler::setSampleRate(int sample_rate) {
+    voice_router_.setSampleRate(sample_rate);
+    global_router_.setSampleRate(sample_rate);
     std::set<Voice*>::iterator iter = all_voices_.begin();
     for (; iter != all_voices_.end(); ++iter)
       (*iter)->processor()->setSampleRate(sample_rate);


### PR DESCRIPTION
Change to allow the VoiceHandler ProcessorRouters to update the sample rate of connected Processors, particularly in regard to SmoothValue.
